### PR TITLE
Added malloc for cfix

### DIFF
--- a/Compiler/types.py
+++ b/Compiler/types.py
@@ -1811,6 +1811,10 @@ class cfix(_number):
         cint_values = map(cfix_to_cint, values)
         writesocketc(client_id, message_type, *cint_values)
 
+    @classmethod
+    def malloc(cls, size):
+        return program.malloc(size, cls)
+    
     @vectorize_init
     def __init__(self, v=None, size=None):
         f = self.f


### PR DESCRIPTION
sfix Array.reveal() will initialize an cfix Array, thus called Array.__init__() -> Array.value_type.malloc(), where cfix.malloc() doesn't exsit.

I noticed that _fix class have a malloc() function, but I can't find a proper way to use that.